### PR TITLE
Fix GitHubUser function

### DIFF
--- a/special.go
+++ b/special.go
@@ -53,6 +53,9 @@ func (c *Config) GitHubToken(host string) (string, error) {
 // GitHubUser detects user name of GitHub from various informations
 func (c *Config) GitHubUser(host string) (string, error) {
 	host = ghHost(host)
+	if user, err := c.Get("user.name"); err == nil {
+		return user, nil
+	}
 	if user := os.Getenv("GITHUB_USER"); user != "" {
 		return user, nil
 	}


### PR DESCRIPTION
The name set by `git config user.name" user-name "` has priority over the environment variable $ USER or $ USERNAME.

